### PR TITLE
adds processing to count fish per PLAD size bin

### DIFF
--- a/scripts/prep_data_for_model.R
+++ b/scripts/prep_data_for_model.R
@@ -524,7 +524,10 @@ write_csv(catch_fl_summary_stream, "data/fork_length_summary_stream.csv")
 
 # measure fork length by PLAD size bin ------------------------------------
 # from meeting with josh 12/27/23 - wants number of fish per PLAD size bin (only measured)
-
+plad_bin_lookup <- tibble(plad_size_bins = c(seq(1:16), "not measured", "outside bins"),
+                          bin_lower = c(seq(from = 35, to = 110,by = 5),NA, NA),
+                          bin_upper = c(seq(from = 39, to = 114, by = 5), NA, NA),
+                          bin_mid = c(seq(from = 37.5, to = 112.5, by = 5), NA, NA))
 plad_distributions_raw <- standard_catch_unmarked |> 
   mutate(week = week(date),
          monitoring_year = ifelse(month(date) %in% 9:12, year(date) + 1, year(date)),
@@ -566,7 +569,11 @@ plad_distributions <- plad_distributions_raw |>
   group_by(stream, site, week, monitoring_year) |> 
   summarize(total = sum(count)) |> 
   left_join(plad_distributions_raw) |> 
-  select(stream, site, week, monitoring_year, lifestage_for_model, plad_size_bins, count, total)
+  select(stream, site, week, monitoring_year, lifestage_for_model, plad_size_bins, count, total) |> 
+  rename(year = monitoring_year) |> 
+  left_join(plad_bin_lookup) |> 
+  # Josh said he is not going to use these
+  filter(!plad_size_bins %in% c("not measured", "outside bins"))
  
 gcs_upload(plad_distributions,
            object_function = f,

--- a/scripts/prep_data_for_model.R
+++ b/scripts/prep_data_for_model.R
@@ -284,7 +284,7 @@ na_filled_lifestage_field <- standard_catch_unmarked_field |>
   filter(count != 0) |> # remove 0 values introduced when 0 prop of a lifestage, significantly decreases size of DF 
   mutate(model_lifestage_method = "assign count based on weekly distribution of field assigned lifestage",
          week = week(date), 
-         year = year(date)) |> 
+         year = year(date)) 
 
 # fill in run for all streams ------------------------------------------
 # how many records have no information for run?
@@ -557,23 +557,8 @@ plad_distributions_raw <- standard_catch_unmarked |>
       fork_length %in% 110:114 ~ "16",
       is.na(fork_length) ~ "not measured",
       fork_length > 114 |
-        fork_length < 35 ~ "outside bins"
-    ),
-    lifestage_for_model = case_when(
-      fork_length > cutoff &
-        !run %in% c("fall", "late fall", "winter") ~ "yearling",
-      fork_length <= cutoff &
-        fork_length > 45 &
-        !run %in% c("fall", "late fall", "winter") ~ "smolt",
-      fork_length > 45 &
-        run %in% c("fall", "late fall", "winter", "not recorded") ~ "smolt",
-      fork_length > 45 &
-        stream == "sacramento river" ~ "smolt",
-      fork_length <= 45 ~ "fry",
-      # logic from flora includes week (all weeks but 7, 8, 9 had this threshold) but I am not sure this is necessary, worth talking through
-      T ~ NA
-    )
-  ) |> 
+        fork_length < 35 ~ "outside bins")
+  ) |>
   group_by(stream, site, week, monitoring_year, plad_size_bins, lifestage_for_model) |> 
   summarize(count = sum(count, na.rm = T))
 


### PR DESCRIPTION
I added a table to summarize the number of fish per fork length PLAD bin. I would like to discuss the lifestage component. I added in the "lifestage_for_model" based on our fork_length cutoffs but I think it needs another look to make sure the yearling cutoffs aren't throwing anything off. We use 45 as distinction between fry/smolt which works well with PLAD size bins.

Please review and we can talk through as needed!