### PR TITLE
fixes issue with adult reach analysis file (was reading in standard f…

### DIFF
--- a/analysis/adult-reach-analysis.R
+++ b/analysis/adult-reach-analysis.R
@@ -8,19 +8,20 @@ library(googleCloudStorageR)
 gcs_auth(json_file = Sys.getenv("GCS_AUTH_FILE"))
 gcs_global_bucket(bucket = Sys.getenv("GCS_DEFAULT_BUCKET"))
 
-gcs_get_object(object_name = "standard-format-data/standard_daily_redd.csv",
+gcs_get_object(object_name = "standard-format-data/standard_redd_raw_reaches.csv",
                bucket = gcs_get_global_bucket(),
                saveToDisk = here::here("data", "standard-format-data", "standard_daily_redd.csv"),
                overwrite = TRUE)
-gcs_get_object(object_name = "standard-format-data/standard_annual_redd.csv",
-               bucket = gcs_get_global_bucket(),
-               saveToDisk = here::here("data", "standard-format-data", "standard_annual_redd.csv"),
-               overwrite = TRUE)
-gcs_get_object(object_name = "standard-format-data/standard_carcass.csv",
+# gcs_get_object(object_name = "standard-format-data/standard_annual_redd.csv",
+#                bucket = gcs_get_global_bucket(),
+#                saveToDisk = here::here("data", "standard-format-data", "standard_annual_redd.csv"),
+#                overwrite = TRUE)
+gcs_get_object(object_name = "standard-format-data/standard_carcass_raw_reaches.csv",
                bucket = gcs_get_global_bucket(),
                saveToDisk = here::here("data", "standard-format-data", "standard_carcass.csv"),
                overwrite = TRUE)
-gcs_get_object(object_name = "standard-format-data/standard_holding.csv",
+# read in raw reaches file
+gcs_get_object(object_name = "standard-format-data/standard_holding_raw_reaches.csv",
                bucket = gcs_get_global_bucket(),
                saveToDisk = here::here("data", "standard-format-data", "standard_holding.csv"),
                overwrite = TRUE)
@@ -45,8 +46,8 @@ gcs_get_object(object_name = "adult-holding-redd-and-carcass-surveys/feather-riv
 
 redd <- read.csv(here::here("data", "standard-format-data", "standard_daily_redd.csv")) |> 
   filter(species != "steelhead")
-annual_redd <- read.csv(here::here("data", "standard-format-data", "standard_annual_redd.csv")) |> 
-  filter(species != "steelhead")
+# annual_redd <- read.csv(here::here("data", "standard-format-data", "standard_annual_redd.csv")) |> 
+#   filter(species != "steelhead")
 carcass <- read.csv(here::here("data", "standard-format-data", "standard_carcass.csv"))
 holding <- read.csv(here::here("data", "standard-format-data", "standard_holding.csv"))
 
@@ -310,7 +311,7 @@ deer_reach_lookup <- tibble("reach" = unique(all_deer_reaches$reach),
   left_join(standard_deer_reaches)
 
 # Mill --------------------------------------------------------------------
-all_mill_reaches <- bind_rows(annual_redd |> 
+all_mill_reaches <- bind_rows(redd |> 
                               filter(stream == "mill creek") |> 
                               mutate(data_type = "redd") |> 
                               select(reach, data_type, year))
@@ -402,7 +403,7 @@ standard_feather_reaches <- tibble("standardized_reach" = c(as.character(seq(1, 
                                                         "Developing Riffle",
                                                         "Swampy Bend",
                                                         NA,
-                                                        "historical reach - no description in data/source"))
+                                                        "historical reach - no description in data/source")) 
 
 # read in feather corrected reach list file (from Casey Campos 1-22-2024)
 feather_reach_clarification <- read_csv(here::here("data-raw", "qc-markdowns", "adult-holding-redd-and-carcass-surveys",
@@ -492,7 +493,7 @@ all_stream_reach_lookup <- bind_rows(battle_reach_lookup |>
                                        mutate(stream = "deer creek"),
                                      mill_reach_lookup |> 
                                        mutate(stream = "mill creek")) |> 
-  distinct(stream, reach, standardized_reach, .keep_all = TRUE)
+  distinct(stream, reach, standardized_reach, sub_reach, standardized_sub_reach, .keep_all = TRUE)
 
 data_dictionary <- tibble(column_name = names(all_stream_reach_lookup),
                           streams_collecting = c("B, C, Bu, F, D, M",
@@ -516,6 +517,3 @@ gcs_upload(all_stream_reach_lookup,
            object_function = f,
            type = "csv",
            name = "jpe-model-data/standard_reach_lookup.csv")
-# TODO pull into the standard adult markdowns (new branch)
-
-

--- a/data-raw/standard-format-data-prep/holding_standard_format.Rmd
+++ b/data-raw/standard-format-data-prep/holding_standard_format.Rmd
@@ -197,6 +197,19 @@ combined_holding <- bind_rows(battle_holding_clean,
                               deer_holding_clean)
 ```
 
+## Save file without standardized reaches
+We need all raw reaches to pull into `analysis/adult-reach-analysis.R`
+
+# Save data
+```{r, save_data}
+f <- function(input, output) write_csv(input, file = output)
+
+gcs_upload(combined_holding,
+           object_function = f,
+           type = "csv",
+           name = "standard-format-data/standard_holding_raw_reaches.csv",
+           predefinedAcl = "bucketLevel")
+```
 ## Survey Reach Standardization
 
 Survey reach naming conventions changed over time for several monitoring programs. A standardized reach lookup table was created in `analysis/adult-reach-analysis.R` and is merged in here to standardize all reaches.

--- a/data-raw/standard-format-data-prep/standard_adult_redd_data.Rmd
+++ b/data-raw/standard-format-data-prep/standard_adult_redd_data.Rmd
@@ -291,6 +291,20 @@ all_redd_data <- bind_rows(clean_battle_redd,
          run = ifelse(is.na(run), "not recorded", run))
 ```
 
+## Save file without standardized reaches
+We need all raw reaches to pull into `analysis/adult-reach-analysis.R`
+
+# Save data
+```{r, save_data}
+f <- function(input, output) write_csv(input, file = output)
+
+gcs_upload(all_redd_data,
+           object_function = f,
+           type = "csv",
+           name = "standard-format-data/standard_redd_raw_reaches.csv",
+           predefinedAcl = "bucketLevel")
+```
+
 ## Survey Reach Standardization
 
 Survey reach naming conventions changed over time for several monitoring programs. A standardized reach lookup table was created in `analysis/adult-reach-analysis.R` and is merged in here to standardize all reaches.
@@ -487,14 +501,10 @@ redd_data_final  |>
 
 ```{r}
 knitr::kable(redd_data_final  |> head())
-
-knitr::kable(redd_count_by_year  |> head())
-
 ```
 
 ```{r, eval=FALSE}
 write_csv(redd_data_final, here::here("data","redd-carcass-holding","standard_all_redd_data.csv"))
-write_csv(redd_count_by_year, here::here("data","redd-carcass-holding","standard_redd_data_by_year.csv"))
 ```
 
 ```{r, eval=FALSE}

--- a/data-raw/standard-format-data-prep/standardized_carcass.Rmd
+++ b/data-raw/standard-format-data-prep/standardized_carcass.Rmd
@@ -258,6 +258,20 @@ carcass_combined <- bind_rows(battle_carcass,
   glimpse()
 ```
 
+###  Save file without standardized reaches
+We need all raw reaches to pull into `analysis/adult-reach-analysis.R`
+
+# Save data
+```{r, save_data}
+f <- function(input, output) write_csv(input, file = output)
+
+gcs_upload(carcass_combined,
+           object_function = f,
+           type = "csv",
+           name = "standard-format-data/standard_carcass_raw_reaches.csv",
+           predefinedAcl = "bucketLevel")
+```
+
 ### Survey Reach Standardization
 
 Survey reach naming conventions changed over time for several monitoring programs. A standardized reach lookup table was created in `analysis/adult-reach-analysis.R` and is merged in here to standardize all reaches.


### PR DESCRIPTION
…ormat, which once joined with reach, was messing up the reaches). now the standard format files save a version to the cloud with the raw reaches, which the analysis script pulls in. gets rid of NAs in the butte creek file by adding subreach to the distinct in analysis script

- fixes circularity in `analysis/adult-reach-analysis.R` and standard format processing for adult files by adding additional google cloud file with raw reaches
- fixes issues with Butte creek by including sub-reaches in `distinct` call in `analysis/adult-reach-analysis.R`